### PR TITLE
`libmtkfmjni`: Address compiler warnings in build

### DIFF
--- a/jni/fmr/Android.mk
+++ b/jni/fmr/Android.mk
@@ -35,6 +35,10 @@ LOCAL_SHARED_LIBRARIES := \
     libmedia \
     liblog
 
+LOCAL_CFLAGS += -Wno-error=unused-but-set-variable \
+	-Wno-error=unused-parameter \
+	-Wno-error=unused-function
+
 LOCAL_MODULE := libmtkfmjni
 LOCAL_MODULE_TAGS := optional
 


### PR DESCRIPTION
This commit addresses build failures from the `-Werror` flag being passed by default. 

Specifically, the warnings were seen in:

* Unused parameter 'idx' in `FMR_chk_cfg_data` and `FMR_stop_scan` functions. 
* Unused variable 'ret' in `FMR_chk_cfg_data`.
* Unused function 'sig_alarm'.

To allow the build to proceed, the following compiler args are made in the `libmtkfmjni` makefile:

* `-Wno-error=unused-but-set-variable`
* `-Wno-error=unused-parameter`
* `-Wno-error=unused-function` 

Fixes build errors related to:

* packages/apps/RevampedFMRadio/jni/fmr/fmr_core.cpp:67
* packages/apps/RevampedFMRadio/jni/fmr/fmr_core.cpp:82
* packages/apps/RevampedFMRadio/jni/fmr/fmr_core.cpp:755
* packages/apps/RevampedFMRadio/jni/fmr/fmr_core.cpp:73