### PR TITLE
RevampedFMRadio: Fix crashes for Android 16

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -34,6 +34,7 @@
     <uses-permission android:name="android.permission.CAPTURE_AUDIO_OUTPUT" />
     <uses-permission android:name="android.permission.CAPTURE_TUNER_AUDIO_INPUT" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_ROUTING" />
@@ -72,6 +73,7 @@
 
         <service
             android:name=".FmService"
+            android:foregroundServiceType="mediaPlayback"
             android:exported="false" >
             <intent-filter>
                 <action android:name="com.android.fmradio.IFmRadioService" />

--- a/src/com/android/fmradio/FmService.java
+++ b/src/com/android/fmradio/FmService.java
@@ -1563,7 +1563,7 @@ public class FmService extends Service implements FmRecorder.OnRecorderStateChan
         }
         filter.addAction(BluetoothA2dp.ACTION_ACTIVE_DEVICE_CHANGED);
         mBroadcastReceiver = new FmServiceBroadcastReceiver();
-        registerReceiver(mBroadcastReceiver, filter);
+        registerReceiver(mBroadcastReceiver, filter, Context.RECEIVER_NOT_EXPORTED);
     }
 
     private void unregisterFmBroadcastReceiver() {
@@ -2126,7 +2126,7 @@ public class FmService extends Service implements FmRecorder.OnRecorderStateChan
         filter.addAction(Intent.ACTION_MEDIA_MOUNTED);
         filter.addAction(Intent.ACTION_MEDIA_UNMOUNTED);
         filter.addAction(Intent.ACTION_MEDIA_EJECT);
-        registerReceiver(mSdcardListener, filter);
+        registerReceiver(mSdcardListener, filter, Context.RECEIVER_NOT_EXPORTED);
     }
 
     private void unregisterSdcardListener() {

--- a/src/com/android/fmradio/FmService.java
+++ b/src/com/android/fmradio/FmService.java
@@ -33,6 +33,7 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.ServiceInfo;
 import android.content.res.Configuration;
 import android.database.Cursor;
 import android.graphics.Bitmap;
@@ -2027,7 +2028,7 @@ public class FmService extends Service implements FmRecorder.OnRecorderStateChan
 
             Notification n = notificationBuilder.build();
             n.flags &= ~Notification.FLAG_NO_CLEAR;
-            startForeground(NOTIFICATION_ID, n);
+            startForeground(NOTIFICATION_ID, n, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
         }
     }
 
@@ -2095,7 +2096,7 @@ public class FmService extends Service implements FmRecorder.OnRecorderStateChan
      * Show notification
      */
     public void showRecordingNotification(Notification notification) {
-        startForeground(NOTIFICATION_ID, notification);
+        startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
     }
 
     /**


### PR DESCRIPTION
These errors were found in the Android 16 (Evolution X) rom.

1- java.lang.SecurityException: com.android.fmradio: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts

2- java.lang.RuntimeException: Unable to stop activity {com.android.fmradio/com.android.fmradio.FmMainActivity}: android.app.MissingForegroundServiceTypeException: Starting FGS without a type  callerApp=ProcessRecord{37b5d49 4295:com.android.fmradio/1000} targetSDK=24 